### PR TITLE
help command: require rubycritic class

### DIFF
--- a/lib/skunk/cli/commands/help.rb
+++ b/lib/skunk/cli/commands/help.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "skunk/cli/commands/base"
+require "rubycritic/commands/help"
 
 module Skunk
   module Cli


### PR DESCRIPTION
Require the rubycritic parent class before using it.

Before this change, `skunk --help` did this:
> Raised a skunk-0.3.1/lib/skunk/cli/commands/help.rb:8:in `<module:Command>': uninitialized constant RubyCritic::Command::Help (NameError)

Hope this helps!