### PR TITLE
Add --version flag

### DIFF
--- a/lib/skunk/cli/commands/version.rb
+++ b/lib/skunk/cli/commands/version.rb
@@ -1,0 +1,15 @@
+require "rubycritic/commands/version"
+module Skunk
+  module Command
+    class Version < RubyCritic::Command::Version
+      def initialize(options)
+        super
+      end
+
+      def execute
+        print Skunk::VERSION
+        status_reporter
+      end
+    end
+  end
+end

--- a/lib/skunk/cli/commands/version.rb
+++ b/lib/skunk/cli/commands/version.rb
@@ -5,7 +5,6 @@ require "rubycritic/commands/version"
 # nodoc #
 module Skunk
   module Command
-
     # Shows skunk version
     class Version < RubyCritic::Command::Version
       def initialize(options)

--- a/lib/skunk/cli/commands/version.rb
+++ b/lib/skunk/cli/commands/version.rb
@@ -7,10 +7,6 @@ module Skunk
   module Command
     # Shows skunk version
     class Version < RubyCritic::Command::Version
-      def initialize(options)
-        super
-      end
-
       def execute
         print Skunk::VERSION
         status_reporter

--- a/lib/skunk/cli/commands/version.rb
+++ b/lib/skunk/cli/commands/version.rb
@@ -1,6 +1,10 @@
 require "rubycritic/commands/version"
+
+# nodoc #
 module Skunk
   module Command
+
+    # Shows skunk version
     class Version < RubyCritic::Command::Version
       def initialize(options)
         super

--- a/lib/skunk/cli/commands/version.rb
+++ b/lib/skunk/cli/commands/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rubycritic/commands/version"
 
 # nodoc #


### PR DESCRIPTION
closes https://github.com/fastruby/skunk/issues/15

Return the version number when you run skunk --version
