### PR TITLE
Fix deprecation warning when running tests

### DIFF
--- a/test/lib/skunk/cli/commands/status_reporter_test.rb
+++ b/test/lib/skunk/cli/commands/status_reporter_test.rb
@@ -32,7 +32,7 @@ describe Skunk::Command::StatusReporter do
     end
 
     it "reports the StinkScore" do
-      reporter.update_status_message.must_equal output
+      _(reporter.update_status_message).must_equal output
     end
   end
 end


### PR DESCRIPTION
```
/Users/bronzdoc/projects/skunk/lib/skunk/cli/commands/status_reporter.rb:29: warning: assigned but unused variable - ttable
Run options: --seed 56097

# Running:

.running flay smells

running flog smells
.
running reek smells
.
running complexity
.
running attributes
.
running churn
.
running simple_cov
.
DEPRECATED: global use of must_equal from /Users/bronzdoc/projects/skunk/test/lib/skunk/cli/commands/status_reporter_test.rb:35. Use _(obj).must_equal instead. This will fail in Minitest 6.
...running flay smells

running flog smells
.
running reek smells
.
running complexity
.
running attributes
.
running churn
.
running simple_cov
.
.

Finished in 0.383928s, 13.0233 runs/s, 13.0233 assertions/s.
5 runs, 5 assertions, 0 failures, 0 errors, 0 skips
```