### PR TITLE
Make variable binding friendly to avoid warning

### DIFF
--- a/lib/skunk/cli/commands/status_reporter.rb
+++ b/lib/skunk/cli/commands/status_reporter.rb
@@ -13,7 +13,7 @@ module Skunk
       HEADINGS = %w[file stink_score churn_times_cost churn cost coverage].freeze
 
       TEMPLATE = ERB.new(<<-TEMPL
-<%= ttable %>\n
+<%= _ttable %>\n
 StinkScore Total: <%= total_stink_score %>
 Modules Analysed: <%= analysed_modules_count %>
 StinkScore Average: <%= stink_score_average %>
@@ -26,7 +26,7 @@ TEMPL
       def update_status_message
         opts = table_options.merge(headings: HEADINGS, rows: table)
 
-        ttable = Terminal::Table.new(opts)
+        _ttable = Terminal::Table.new(opts)
 
         @status_message = TEMPLATE.result(binding)
       end


### PR DESCRIPTION
Ruby thinks `ttable` is unused since is not used in the current block. In this case the variable is used in the `binding` context. 

To bypass this warning we can rename the variable to start with an `_`

```
rake test
warning: assigned but unused variable - ttable
....
```