### PR TITLE
Create compare_root_directory when it does not exist

### DIFF
--- a/lib/skunk/cli/commands/compare.rb
+++ b/lib/skunk/cli/commands/compare.rb
@@ -2,6 +2,7 @@
 
 require "rubycritic/commands/compare"
 require "skunk/rubycritic/analysed_modules_collection"
+require "skunk/cli/commands/output"
 
 # nodoc #
 module Skunk
@@ -29,17 +30,16 @@ module Skunk
       # create a txt file with the branch score details
       def build_details
         details = "Base branch (#{::RubyCritic::Config.base_branch}) "\
-                  "average stink score: #{::RubyCritic::Config.base_branch_score} \n"\
-                  "Feature branch (#{::RubyCritic::Config.feature_branch}) "\
-                  "average stink score: #{::RubyCritic::Config.feature_branch_score} \n"
+          "average stink score: #{::RubyCritic::Config.base_branch_score} \n"\
+          "Feature branch (#{::RubyCritic::Config.feature_branch}) "\
+          "average stink score: #{::RubyCritic::Config.feature_branch_score} \n"
+        Skunk::Command::Output.create_directory(::RubyCritic::Config.compare_root_directory)
         File.open(build_details_path, "w") { |file| file.write(details) }
         puts details
       end
 
       def build_details_path
-        compare_root_directory = ::RubyCritic::Config.compare_root_directory
-        FileUtils.mkdir_p(compare_root_directory) unless File.exist?(compare_root_directory)
-        "#{compare_root_directory}/build_details.txt"
+        "#{::RubyCritic::Config.compare_root_directory}/build_details.txt"
       end
     end
   end

--- a/lib/skunk/cli/commands/compare.rb
+++ b/lib/skunk/cli/commands/compare.rb
@@ -37,7 +37,12 @@ module Skunk
       end
 
       def build_details_path
-        "#{::RubyCritic::Config.compare_root_directory}/build_details.txt"
+        FileUtils.mkdir_p(compare_root_directory) unless File.exists?(compare_root_directory)
+        "#{compare_root_directory}/build_details.txt"
+      end
+
+      def compare_root_directory
+        ::RubyCritic::Config.compare_root_directory
       end
     end
   end

--- a/lib/skunk/cli/commands/compare.rb
+++ b/lib/skunk/cli/commands/compare.rb
@@ -37,12 +37,9 @@ module Skunk
       end
 
       def build_details_path
+        compare_root_directory = ::RubyCritic::Config.compare_root_directory
         FileUtils.mkdir_p(compare_root_directory) unless File.exists?(compare_root_directory)
         "#{compare_root_directory}/build_details.txt"
-      end
-
-      def compare_root_directory
-        ::RubyCritic::Config.compare_root_directory
       end
     end
   end

--- a/lib/skunk/cli/commands/compare.rb
+++ b/lib/skunk/cli/commands/compare.rb
@@ -38,7 +38,7 @@ module Skunk
 
       def build_details_path
         compare_root_directory = ::RubyCritic::Config.compare_root_directory
-        FileUtils.mkdir_p(compare_root_directory) unless File.exists?(compare_root_directory)
+        FileUtils.mkdir_p(compare_root_directory) unless File.exist?(compare_root_directory)
         "#{compare_root_directory}/build_details.txt"
       end
     end

--- a/lib/skunk/cli/commands/output.rb
+++ b/lib/skunk/cli/commands/output.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Skunk
+  module Command
+    # Implements the needed methods for a successful compare output
+    class Output
+      def self.create_directory(directory)
+        FileUtils.mkdir_p(directory) unless File.exist?(directory)
+      end
+    end
+  end
+end

--- a/test/lib/skunk/cli/commands/compare_test.rb
+++ b/test/lib/skunk/cli/commands/compare_test.rb
@@ -25,9 +25,10 @@ describe Skunk::Command::Compare do
     end
 
     it "creates the compare_root_directory if it doesn't exist" do
-      ::RubyCritic::Config.configuration.stub(:compare_root_directory, compare_root_directory) do
+      ::RubyCritic::Config.configuration.stub(:compare_root_directory,
+                                              compare_root_directory) do
         Skunk::Command::Compare.new(paths: "samples/rubycritic").build_details
-        _(File.exists?(compare_root_directory)).must_equal true
+        _(File.exist?(compare_root_directory)).must_equal true
       end
     end
   end

--- a/test/lib/skunk/cli/commands/compare_test.rb
+++ b/test/lib/skunk/cli/commands/compare_test.rb
@@ -7,10 +7,12 @@ require "skunk/cli/commands/compare"
 
 describe Skunk::Command::Compare do
   let(:paths) { "samples/rubycritic" }
+  let(:compare_root_directory) { "test/support/tmp/rubycritic/compare/" }
 
   describe "#analyse_branch" do
     before do
       RubyCritic::Config.root = paths
+      FileUtils.rm_rf("test/support/")
     end
 
     it "sets the stink_score_average as the branch score" do
@@ -19,6 +21,13 @@ describe Skunk::Command::Compare do
         compare.analyse_branch(:base_branch)
 
         _(RubyCritic::Config.base_branch_score).must_equal 58.88
+      end
+    end
+
+    it "creates the compare_root_directory if it doesn't exist" do
+      ::RubyCritic::Config.configuration.stub(:compare_root_directory, compare_root_directory) do
+        Skunk::Command::Compare.new(paths: "samples/rubycritic").build_details
+        _(File.exists?(compare_root_directory)).must_equal true
       end
     end
   end


### PR DESCRIPTION
As seen in https://github.com/fastruby/skunk/issues/12. If you use the branch comparison feature it fails when trying to write the `build_details` if the current `::RubyCritic::Config.compare_root_directory` doesn't exist.

I'm adding a small workaround here to fix that, which is to check if that directory exists, if it doesn't, then we create it and proceed to write the `build_details` to the build_details.txt file as normal.