### PR TITLE
Fix logo display

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Skunk
 
-![skunk](https://github.com/fastruby/skunk/raw/master/logo.png")
+![skunk](https://github.com/fastruby/skunk/raw/master/logo.png)
 
 
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v1.4%20adopted-ff69b4.svg)](code-of-conduct.md) [![Build Status](https://travis-ci.org/fastruby/skunk.svg?branch=master)](https://travis-ci.org/fastruby/skunk) [![Maintainability](https://api.codeclimate.com/v1/badges/3e33d701ced16eee2420/maintainability)](https://codeclimate.com/github/fastruby/skunk/maintainability) [![Docs](http://img.shields.io/badge/yard-docs-blue.svg)](http://rubydoc.info/gems/skunk)


### PR DESCRIPTION
Name of the logo has a double quote at the end `"`