### PR TITLE
Feature/status output version number

### DIFF
--- a/lib/skunk/cli/commands/status_reporter.rb
+++ b/lib/skunk/cli/commands/status_reporter.rb
@@ -20,6 +20,8 @@ StinkScore Total: <%= total_stink_score %>
 Modules Analysed: <%= analysed_modules_count %>
 StinkScore Average: <%= stink_score_average %>
 <% if worst %>Worst StinkScore: <%= worst.stink_score %> (<%= worst.pathname %>)<% end %>
+
+Generated with Skunk v<%= Skunk::VERSION %>
 TEMPL
                         )
 

--- a/test/lib/skunk/cli/commands/status_reporter_test.rb
+++ b/test/lib/skunk/cli/commands/status_reporter_test.rb
@@ -32,7 +32,8 @@ describe Skunk::Command::StatusReporter do
     end
 
     it "reports the StinkScore" do
-      _(reporter.update_status_message).must_equal output
+      _(reporter.update_status_message).must_include output
+      _(reporter.update_status_message).must_include "Generated with Skunk v#{Skunk::VERSION}"
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,6 +19,7 @@ end
 require "minitest/autorun"
 require "minitest/pride"
 require "minitest/around/spec"
+require "skunk/rubycritic/analysed_module"
 
 def context(*args, &block)
   describe(*args, &block)


### PR DESCRIPTION
Hey, 

This PR adds a line to the end of the status reporter. 

This way it will be easier to know what version someone used to generate their skunk report: 

<img width="972" alt="Screen Shot 2020-04-05 at 1 38 46 PM" src="https://user-images.githubusercontent.com/17584/78505873-4f4ab900-7744-11ea-89bd-f06128a7082b.png">

Please check it out.

Thanks! 