### PR TITLE
Add issue template to make it easier to submit bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,64 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG] "
+labels: 'bug'
+assignees: ''
+
+---
+
+**IMPORTANT: please make sure you ask yourself all intro questions and fill all sections of the template.**
+
+**Before we start...:**
+
+- [ ] I checked the documentation and found no answer
+- [ ] I checked to make sure that this issue has not already been filed
+- [ ] I'm reporting the issue to the correct repository (for multi-repository projects)
+
+
+**Branch/Commit:**
+
+Inform what branch/commit of Skunk you are using.
+
+**Expected behavior:**
+
+Please include a detailed description of the behavior you were expecting when you encountered this issue.
+
+**Actual behavior:**
+
+Please include a detailed description of the actual behavior of the application.
+
+**Steps to reproduce:**
+
+How do I achieve this behavior? Use the following format to provide a step-by-step guide:
+
+1. Step 1: ...
+2. Step 2: ...
+
+**Context and environment:**
+
+Provide any relevant information about your setup (Customize the list accordingly based on what info is relevant to this project)
+
+1. Version of the software the issue is being opened for.
+2. Operating System
+3. Operating System version
+4. Browser
+5. Browser version
+6. Device
+7. Firmware version
+8. SDK version
+9. Toolchain version
+
+_Delete any information that is not relevant._
+
+If you are unable to reproduce the bug, add the **Non-Reproducible** tag and describe the steps you followed leading to the bug to the best of your recollection.
+
+**Screenshots and Videos**
+
+If the issue has an effect in the frontend, include any relevant screenshots and videos here.
+
+**Logs**
+
+Include relevant log snippets or files here.
+
+**I will abide by the [code of conduct] (https://github.com/fastruby/skunk/blob/master/CODE_OF_CONDUCT.md)**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: "[BUG] "
 labels: 'bug'
-assignees: ''
+assignees: 'black-bunny-brigade'
 
 ---
 
@@ -16,9 +16,9 @@ assignees: ''
 - [ ] I'm reporting the issue to the correct repository (for multi-repository projects)
 
 
-**Branch/Commit:**
+**Version, Branch, or Commit:**
 
-Inform what branch/commit of Skunk you are using.
+Inform what version, branch, commit of Skunk you are using.
 
 **Expected behavior:**
 
@@ -42,20 +42,9 @@ Provide any relevant information about your setup (Customize the list accordingl
 1. Version of the software the issue is being opened for.
 2. Operating System
 3. Operating System version
-4. Browser
-5. Browser version
-6. Device
-7. Firmware version
-8. SDK version
-9. Toolchain version
+4. Ruby version
 
 _Delete any information that is not relevant._
-
-If you are unable to reproduce the bug, add the **Non-Reproducible** tag and describe the steps you followed leading to the bug to the best of your recollection.
-
-**Screenshots and Videos**
-
-If the issue has an effect in the frontend, include any relevant screenshots and videos here.
 
 **Logs**
 


### PR DESCRIPTION
Hi folks,

I noticed we don't have an issue template in this project so I decided to add one.

This will give some structure to the process of submitting a bug to the project.

Thoughts? 

Thanks, 
Ernesto 