### PR TITLE
Fix changelog uri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [FEATURE: Add PR Template](https://github.com/fastruby/skunk/pull/72)
 * [BUGFIX: Fix Sponsorship logo path in README](https://github.com/fastruby/skunk/pull/73)
 * [BUGFIX: Test with Ruby 3.1](https://github.com/fastruby/skunk/pull/85)
+* [BUGFIX: Fix changelog uri](https://github.com/fastruby/skunk/pull/90)
 
 ## v0.5.1 / 2021-02-17 [(commits)](https://github.com/fastruby/skunk/compare/v0.5.0...v0.5.1)
 

--- a/skunk.gemspec
+++ b/skunk.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
     spec.metadata["homepage_uri"] = spec.homepage
     spec.metadata["source_code_uri"] = "https://github.com/fastruby/skunk"
-    spec.metadata["changelog_uri"] = "https://github.com/fastruby/skunk/changelog"
+    spec.metadata["changelog_uri"] = "https://github.com/fastruby/skunk/blob/main/CHANGELOG.md"
   else
     raise "RubyGems 2.0 or newer is required to protect against " \
       "public gem pushes."


### PR DESCRIPTION
Metadata for the `changelog_uri` is not pointing out in the right direction, so this PR fixes the issue

I will abide by the [code of conduct](https://github.com/fastruby/skunk/blob/main/CODE_OF_CONDUCT.md).
