### PR TITLE
Add filters to only calculate coverage for relevant files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## main [(unreleased)](https://github.com/fastruby/skunk/compare/v0.5.2...HEAD)
 
 * <INSERT YOUR FEATURE OR BUGFIX HERE>
+
+* [BUGFIX: Better test coverage tracking for skunk](https://github.com/fastruby/skunk/pull/108)
 * [FEATURE: Add Ruby 3.2 Support](https://github.com/fastruby/skunk/pull/106)
 * [BUGFIX: Fix skunk workflow](https://github.com/fastruby/skunk/pull/104)
 * [BUGFIX: Fix documentation and refactor `skunk_score` method](https://github.com/fastruby/skunk/pull/102)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,6 +12,9 @@ if ENV["COVERAGE"] == "true"
   ]
 
   SimpleCov.start do
+    add_filter "lib/skunk/version.rb"
+    add_filter "test/lib"
+
     track_files "lib/**/*.rb"
   end
 


### PR DESCRIPTION
- [ ] Add an entry to `CHANGELOG.md` that links to this PR under the "main (unreleased)" heading.

Description:

This improves the SimpleCov configuration to only track relevant files. 

✅ I will abide by the [code of conduct](https://github.com/fastruby/skunk/blob/main/CODE_OF_CONDUCT.md).
