### PR TITLE
Bump dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        ruby-version: [2.6, 2.7, "3.0", 3.1, 3.2]
+        ruby-version: ["2.6", "2.7", "3.0", "3.1", "3.2"]
     steps:
       - uses: actions/checkout@v2
       - name: Setup Ruby ${{ matrix.ruby-version }}

--- a/skunk.gemspec
+++ b/skunk.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rubycritic", ">= 4.5.2", "< 5.0"
-  spec.add_dependency "terminal-table", "~> 1.8.0"
+  spec.add_dependency "terminal-table", "~> 3.0"
 
   spec.add_development_dependency "codecov", "~> 0.1.16"
   spec.add_development_dependency "debug"
@@ -48,8 +48,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest-stub_any_instance", "~> 1.0.2"
   spec.add_development_dependency "minitest-stub-const", "~> 0.6"
   spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "reek", "~> 6.0.0"
-  spec.add_development_dependency "rubocop", "~> 1.0"
+  spec.add_development_dependency "reek", "~> 6.1"
+  spec.add_development_dependency "rubocop", "~> 1.48"
   spec.add_development_dependency "simplecov", "~> 0.18"
   spec.add_development_dependency "simplecov-console", "0.5.0"
   spec.add_development_dependency "webmock", "~> 3.10.0"


### PR DESCRIPTION
- [ ] Add an entry to `CHANGELOG.md` that links to this PR under the "main (unreleased)" heading.

Description:

This PR updates dependencies so that `skunk` can use the latest dependencies. 

I will abide by the [code of conduct](https://github.com/fastruby/skunk/blob/main/CODE_OF_CONDUCT.md).
