### PR TITLE
Update expectation to be more convenient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * <INSERT YOUR FEATURE OR BUGFIX HERE>
 
+* [ENHANCEMENT: Better test suite with more relaxed console output expectation](https://github.com/fastruby/skunk/pull/117)
+
 ## v0.5.3 / 2023-12-01 [(commits)](https://github.com/fastruby/skunk/compare/v0.5.2...v0.5.3)
 
 * [BUGFIX: Update reek, rubocop, and terminal-table dependencies](https://github.com/fastruby/skunk/pull/111)

--- a/test/lib/skunk/application_test.rb
+++ b/test/lib/skunk/application_test.rb
@@ -53,7 +53,7 @@ describe Skunk::Cli::Application do
         end
 
         _(File.read("tmp/generated_report.txt"))
-          .must_equal File.read("test/samples/console_output.txt")
+          .must_include File.read("test/samples/console_output.txt")
       end
     end
 

--- a/test/samples/console_output.txt
+++ b/test/samples/console_output.txt
@@ -8,5 +8,3 @@ SkunkScore Total: 0.59
 Modules Analysed: 1
 SkunkScore Average: 0.59
 Worst SkunkScore: 0.59 (samples/rubycritic/analysed_module.rb)
-
-Generated with Skunk v0.5.2


### PR DESCRIPTION
- [ ] Add an entry to `CHANGELOG.md` that links to this PR under the "main (unreleased)" heading.

Description:

This PR removes the version number from the console output expectation, which makes it easier to keep the test suite in a passing state.

If changes to the behavior are made, clearly describe what changes.

I will abide by the [code of conduct](https://github.com/fastruby/skunk/blob/main/CODE_OF_CONDUCT.md).
