### PR TITLE
Release work for v0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## main [(unreleased)](https://github.com/fastruby/skunk/compare/v0.5.3...HEAD)
+## main [(unreleased)](https://github.com/fastruby/skunk/compare/v0.5.4...HEAD)
 
 * <INSERT YOUR FEATURE OR BUGFIX HERE>
+
+## v0.5.4 / 2025-05-05 [(commits)](https://github.com/fastruby/skunk/compare/v0.5.3...v0.5.4)
 
 * [FEATURE: Generate JSON report in background](https://github.com/fastruby/skunk/pull/119)
 * [ENHANCEMENT: Better test suite with more relaxed console output expectation](https://github.com/fastruby/skunk/pull/117)

--- a/lib/skunk/version.rb
+++ b/lib/skunk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Skunk
-  VERSION = "0.5.3"
+  VERSION = "0.5.4"
 end


### PR DESCRIPTION

- [x] Add an entry to `CHANGELOG.md` that links to this PR under the "main (unreleased)" heading.

Description:

 Release v0.5.4

I will abide by the [code of conduct](https://github.com/fastruby/skunk/blob/main/CODE_OF_CONDUCT.md).
