### PR TITLE
Update Rubycritic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## main [(unreleased)](https://github.com/fastruby/skunk/compare/v0.5.4...HEAD)
 
+* [ENHANCEMENT: Change RubyCritic requirements to >= 4.11](https://github.com/fastruby/skunk/pull/132)
 * [REFACTOR: Move Console Report](https://github.com/fastruby/skunk/pull/128)
 * [BUGFIX: Set the right content type in the share HTTP request](https://github.com/fastruby/skunk/pull/129)
 * [REFACTOR: Centralize Skunk analysis into RubyCritic module](https://github.com/fastruby/skunk/pull/127)

--- a/skunk.gemspec
+++ b/skunk.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubycritic", ">= 4.5.2", "< 5.0"
+  spec.add_dependency "rubycritic", ">= 4.11", "< 5.0"
   spec.add_dependency "terminal-table", "~> 3.0"
 
   spec.add_development_dependency "codecov", "~> 0.1.16"


### PR DESCRIPTION
- [ ] Add an entry to `CHANGELOG.md` that links to this PR under the "main (unreleased)" heading.

Description:

Simply updates the minimum RubyCritic version to 4.11 which brings in an important performance improvement

I will abide by the [code of conduct](https://github.com/fastruby/skunk/blob/main/CODE_OF_CONDUCT.md).
