### PR TITLE
Support SimpleCov 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## main [(unreleased)](https://github.com/fastruby/skunk/compare/v0.5.4...HEAD)
 
-* [FEATURE: Support SimpleCov 1.0](https://github.com/fastruby/skunk/pull/140)
+* [ENHANCEMENT: Support SimpleCov 1.0](https://github.com/fastruby/skunk/pull/140)
 * BUGFIX: Pin path_expander < 2.0 for Ruby 2.7 compatibility
 * [FEATURE: Add `--formats` CLI flag to select report formats (json, html, console)](https://github.com/fastruby/skunk/pull/130)
 * [REFACTOR: Move Console Report](https://github.com/fastruby/skunk/pull/128)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## main [(unreleased)](https://github.com/fastruby/skunk/compare/v0.5.4...HEAD)
 
+* [FEATURE: Support SimpleCov 1.0](https://github.com/fastruby/skunk/pull/140)
 * BUGFIX: Pin path_expander < 2.0 for Ruby 2.7 compatibility
 * [FEATURE: Add `--formats` CLI flag to select report formats (json, html, console)](https://github.com/fastruby/skunk/pull/130)
 * [REFACTOR: Move Console Report](https://github.com/fastruby/skunk/pull/128)

--- a/skunk.gemspec
+++ b/skunk.gemspec
@@ -51,7 +51,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "reek"
   spec.add_development_dependency "rubocop"
-  spec.add_development_dependency "simplecov", ">= 0.18"
+  spec.add_development_dependency "simplecov", ">= 0.18", "< 2"
   spec.add_development_dependency "simplecov-console", "0.5.0"
   spec.add_development_dependency "webmock", "~> 3.20.0"
 end

--- a/skunk.gemspec
+++ b/skunk.gemspec
@@ -51,7 +51,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "reek"
   spec.add_development_dependency "rubocop"
-  spec.add_development_dependency "simplecov", "~> 0.18"
+  spec.add_development_dependency "simplecov", ">= 0.18"
   spec.add_development_dependency "simplecov-console", "0.5.0"
   spec.add_development_dependency "webmock", "~> 3.20.0"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,10 +16,10 @@ if ENV["COVERAGE"] == "true"
   SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(formatters)
 
   SimpleCov.start do
-    add_filter "lib/skunk/version.rb"
-    add_filter "test/lib"
+    skip "lib/skunk/version.rb"
+    skip "test/lib"
 
-    track_files "lib/**/*.rb"
+    cover "lib/**/*.rb"
   end
 
   puts "Using SimpleCov v#{SimpleCov::VERSION}"


### PR DESCRIPTION
- [x] Add an entry to `CHANGELOG.md` that links to this PR under the "main (unreleased)" heading.

## Description
Adds support for SimpleCov 1.0 in development

I will abide by the [code of conduct](https://github.com/fastruby/skunk/blob/main/CODE_OF_CONDUCT.md).
